### PR TITLE
task2209 txemi arreglar relacion osmatch osclass

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group = 'org.nmap4j'
-version = '1.0.11'
+version = '1.0.12'
 
 description = 'A Java nmap wrapper'
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group = 'org.nmap4j'
-version = '1.0.10'
+version = '1.0.11'
 
 description = 'A Java nmap wrapper'
 

--- a/src/main/java/org/nmap4j/data/host/os/OsMatch.java
+++ b/src/main/java/org/nmap4j/data/host/os/OsMatch.java
@@ -34,6 +34,8 @@
  */
 package org.nmap4j.data.host.os;
 
+import java.util.ArrayList;
+
 public class OsMatch {
 	
 	public final static String OS_MATCH_TAG = "osmatch" ;
@@ -45,7 +47,13 @@ public class OsMatch {
 	private String name ; 
 	private String accuracy ;
 	private String line ;
-	
+
+	private ArrayList<OsClass> osClasses ;
+
+	public OsMatch(){
+		osClasses = new ArrayList<OsClass>() ;
+	}
+
 	public String getName() {
 		return name;
 	}
@@ -63,6 +71,18 @@ public class OsMatch {
 	}
 	public void setLine(String line) {
 		this.line = line;
+	}
+	public ArrayList<OsClass> getOsClasses() {
+		return osClasses;
+	}
+	public void setOsClasses(ArrayList<OsClass> osClasses) {
+		this.osClasses = osClasses;
+	}
+	public boolean addOsClass(OsClass o) {
+		return osClasses.add(o);
+	}
+	public boolean removeOsClass(OsClass o) {
+		return osClasses.remove(o);
 	}
 	@Override
 	public String toString() {

--- a/src/main/java/org/nmap4j/parser/NMapXmlHandler.java
+++ b/src/main/java/org/nmap4j/parser/NMapXmlHandler.java
@@ -322,7 +322,7 @@ public class NMapXmlHandler extends DefaultHandler {
 			if (previousQName.equals(OsClass.OSCLASS_TAG)) {
 				osClass.addCpe(cpe);
 			} else if (previousQName.equals(Service.SERVICE_TAG)) {
-
+				// TODO: This can happen but no need to implement for me.
 			}
 		} else if (qName.equals(Trace.TRACE_TAG)) {
 			if(trace!=null){

--- a/src/main/java/org/nmap4j/parser/NMapXmlHandler.java
+++ b/src/main/java/org/nmap4j/parser/NMapXmlHandler.java
@@ -76,7 +76,7 @@ import java.util.List;
 public class NMapXmlHandler extends DefaultHandler {
 	final static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-	private static List<NMap4JParserEventListener> listeners;
+	private List<NMap4JParserEventListener> listeners;
 
 	private final INMapRunHandler runHandler;
 
@@ -127,6 +127,9 @@ public class NMapXmlHandler extends DefaultHandler {
 	}
 
 	private void fireEvent(Object payload) {
+		if(payload==null){
+			throw new InternalError("Nmap XML error, end tag with no beginning?");
+		}
 		ParserEvent event = new ParserEvent(this, payload);
 		if (listeners != null && listeners.size() > 0) {
 			Iterator<NMap4JParserEventListener> listenersIterator = listeners.iterator();
@@ -139,14 +142,14 @@ public class NMapXmlHandler extends DefaultHandler {
 		}
 	}
 
-	public static void addListener(NMap4JParserEventListener listener) {
+	public void addListener(NMap4JParserEventListener listener) {
 		if (listeners == null) {
 			listeners = new ArrayList<>();
 		}
 		listeners.add(listener);
 	}
 
-	public static void removeListener(NMap4JParserEventListener listener) {
+	public void removeListener(NMap4JParserEventListener listener) {
 		listeners.remove(listener);
 	}
 
@@ -155,114 +158,103 @@ public class NMapXmlHandler extends DefaultHandler {
 		parseStartTime = System.currentTimeMillis();
 	}
 
+	private static String nestedTagErrorMsg(String tagName) {
+		return String.format( "Error processing {} nmap XML tag inside {} tag. nested twice? his should not happen.", tagName , tagName );
+	}
+
 	@Override
 	public void startElement(String uri, String localName, String qName,
 							 Attributes attributes) throws SAXException {
 
 		if (qName.equals(NMapRun.NMAPRUN_TAG)) {
 			nmapRun = runHandler.createNMapRun(attributes);
-		}
-		if (qName.equals(ScanInfo.SCANINFO_TAG)) {
+		} else if (qName.equals(ScanInfo.SCANINFO_TAG)) {
 			if(scanInfo!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName) );
 			}
 			scanInfo = runHandler.createScanInfo(attributes);
 			nmapRun.setScanInfo(scanInfo);
-		}
-		if (qName.equals(Debugging.DEBUGGING_TAG)) {
+		} else if (qName.equals(Debugging.DEBUGGING_TAG)) {
 			if(debugging!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			debugging = runHandler.createDebugging(attributes);
 			nmapRun.setDebugging(debugging);
-		}
-		if (qName.equals(Verbose.VERBOSE_TAG)) {
+		} else if (qName.equals(Verbose.VERBOSE_TAG)) {
 			if(verbose!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			verbose = runHandler.createVerbose(attributes);
 			nmapRun.setVerbose(verbose);
-		}
-		if (qName.equals(Host.HOST_TAG)) {
+		} else if (qName.equals(Host.HOST_TAG)) {
 			if(host!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			host = runHandler.createHost(attributes);
 			nmapRun.addHost(host);
-		}
-		if (qName.equals(Status.STATUS_TAG)) {
+		} else if (qName.equals(Status.STATUS_TAG)) {
 			if(status!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			status = runHandler.createStatus(attributes);
 			host.setStatus(status);
-		}
-		if (qName.equals(Address.ADDRESS_TAG)) {
+		} else if (qName.equals(Address.ADDRESS_TAG)) {
 			if(address!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			address = runHandler.createAddress(attributes);
 			host.addAddress(address);
-		}
-		if (qName.equals(Hostnames.HOSTNAMES_TAG)) {
+		} else if (qName.equals(Hostnames.HOSTNAMES_TAG)) {
 			if(hostnames!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			hostnames = runHandler.createHostnames(attributes);
 			host.setHostnames(hostnames);
-		}
-		if (qName.equals(Hostname.HOSTNAME_TAG)) {
+		} else if (qName.equals(Hostname.HOSTNAME_TAG)) {
 			if(hostname!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			hostname = runHandler.createHostname(attributes);
 			hostnames.setHostname(hostname);
-		}
-		if (qName.equals(Ports.PORTS_TAG)) {
+		} else if (qName.equals(Ports.PORTS_TAG)) {
 			if(ports!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			ports = runHandler.createPorts(attributes);
 			host.setPorts(ports);
-		}
-		if (qName.equals(Port.PORT_TAG)) {
+		} else if (qName.equals(Port.PORT_TAG)) {
 			if(port!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			port = runHandler.createPort(attributes);
 			ports.addPort(port);
-		}
-		if (qName.equals(State.STATE_TAG)) {
+		} else if (qName.equals(State.STATE_TAG)) {
 			if(state!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			state = runHandler.createState(attributes);
 			port.setState(state);
-		}
-		if (qName.equals(Service.SERVICE_TAG)) {
+		} else if (qName.equals(Service.SERVICE_TAG)) {
 			if(service!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			service = runHandler.createService(attributes);
 			port.setService(service);
-		}
-		if (qName.equals(Os.OS_TAG)) {
+		} else if (qName.equals(Os.OS_TAG)) {
 			if(os!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			os = runHandler.createOs(attributes);
 			host.setOs(os);
-		}
-		if (qName.equals(PortUsed.PORT_USED_TAG)) {
+		} else if (qName.equals(PortUsed.PORT_USED_TAG)) {
 			if(portUsed!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			portUsed = runHandler.createPortUsed(attributes);
 			os.addPortUsed(portUsed);
-		}
-		if (qName.equals(OsClass.OSCLASS_TAG)) {
+		} else if (qName.equals(OsClass.OSCLASS_TAG)) {
 			if(osClass!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			osClass = runHandler.createOsClass(attributes);
 			if(osMatch==null ){
@@ -270,71 +262,61 @@ public class NMapXmlHandler extends DefaultHandler {
 			}else  {
 				osMatch.addOsClass( osClass );
 			}
-		}
-		if (qName.equals(OsMatch.OS_MATCH_TAG)) {
+		} else if (qName.equals(OsMatch.OS_MATCH_TAG)) {
 			if(osMatch!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			osMatch = runHandler.createOsMatch(attributes);
 			os.addOsMatch(osMatch);
-		}
-		if (qName.equals(Distance.DISTANCE_TAG)) {
+		} else if (qName.equals(Distance.DISTANCE_TAG)) {
 			if(distance!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			distance = runHandler.createDistance(attributes);
 			host.setDistance(distance);
-		}
-		if (qName.equals(TcpSequence.TCP_SEQUENCE_TAG)) {
+		} else if (qName.equals(TcpSequence.TCP_SEQUENCE_TAG)) {
 			if(tcpSequence!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			tcpSequence = runHandler.createTcpSequence(attributes);
 			host.setTcpSequence(tcpSequence);
-		}
-		if (qName.equals(TcpTsSequence.TCP_TS_SEQUENCE_TAG)) {
+		} else if (qName.equals(TcpTsSequence.TCP_TS_SEQUENCE_TAG)) {
 			if(tcpTsSequence!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			tcpTsSequence = runHandler.createTcpTsSequence(attributes);
 			host.setTcpTsSequence(tcpTsSequence);
-		}
-		if (qName.equals(Times.TIMES_TAG)) {
+		} else if (qName.equals(Times.TIMES_TAG)) {
 			if(times!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			times = runHandler.createTimes(attributes);
 			host.setTimes(times);
-		}
-		if (qName.equals(Uptime.UPTIME_TAG)) {
+		} else if (qName.equals(Uptime.UPTIME_TAG)) {
 			if(uptime!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			uptime = runHandler.createUptime(attributes);
 			host.setUptime(uptime);
-		}
-		if (qName.equals(RunStats.RUNSTATS_TAG)) {
+		} else if (qName.equals(RunStats.RUNSTATS_TAG)) {
 			if(runStats!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			runStats = runHandler.createRunStats(attributes);
 			nmapRun.setRunStats(runStats);
-		}
-		if (qName.equals(Finished.FINISHED_TAG)) {
+		} else if (qName.equals(Finished.FINISHED_TAG)) {
 			if(finished!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			finished = runHandler.createFinished(attributes);
 			runStats.setFinished(finished);
-		}
-		if (qName.equals(Hosts.HOSTS_TAG)) {
+		} else if (qName.equals(Hosts.HOSTS_TAG)) {
 			if(hosts!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			hosts = runHandler.createHosts(attributes);
 			runStats.setHosts(hosts);
-		}
-		if (qName.equals(Cpe.CPE_ATTR)) {
+		} else if (qName.equals(Cpe.CPE_ATTR)) {
 			isCpeData = true;
 			cpe = runHandler.createCpe(attributes);
 			if (previousQName.equals(OsClass.OSCLASS_TAG)) {
@@ -342,30 +324,25 @@ public class NMapXmlHandler extends DefaultHandler {
 			} else if (previousQName.equals(Service.SERVICE_TAG)) {
 
 			}
-		}
-		if (qName.equals(Trace.TRACE_TAG)) {
+		} else if (qName.equals(Trace.TRACE_TAG)) {
 			if(trace!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			trace = runHandler.createTrace(attributes);
 			host.setTrace(trace);
-		}
-		if (qName.equals(Hop.HOP_TAG)) {
+		} else if (qName.equals(Hop.HOP_TAG)) {
 			if(hop!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			hop = runHandler.createHop(attributes);
 			trace.addHop(hop);
-		}
-
-		if (qName.equals(HostScript.TAG)) {
+		} else if (qName.equals(HostScript.TAG)) {
 			if(hostScript!=null){
-				throw new RuntimeException(  );
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			hostScript = runHandler.createHostScript(attributes);
 			host.setHostScript(this.hostScript);
-		}
-		if (qName.equals(Script.TAG)) {
+		} else if (qName.equals(Script.TAG)) {
 			if (this.hostScript != null) {
 				// There are mor tags named script that are not this case.
 				this.script = runHandler.createScript(attributes);
@@ -375,15 +352,14 @@ public class NMapXmlHandler extends DefaultHandler {
 				this.port.addScript(this.script);
 			}else{
 				if("postscript".equals( previousQName) ){
-					// puede ser, no esta implementado
+					// TODO: This can happen but is not implemented yet.
 				}else{
-					throw new RuntimeException(  );
+					throw new UnsupportedOperationException( "This is not supported because never happened in a wide range of tested data." );
 				}
 			}
-		}
-		if (qName.equals(Script.ELEMTAG)) {
+		} else if (qName.equals(Script.ELEMTAG)) {
 			if (this.elemkey != null) {
-				throw new InternalError("If we start this element none should be previously created. This should not happen.");
+				throw new InternalError( nestedTagErrorMsg(qName));
 			}
 			// sometimes this.script == null in practice so I will not check it. Not sure if it should be.
 			this.elemkey = attributes.getValue("key");
@@ -416,126 +392,96 @@ public class NMapXmlHandler extends DefaultHandler {
 		if (qName.equals(NMapRun.NMAPRUN_TAG)) {
 			fireEvent(nmapRun);
 			nmapRun = null;
-		}
-		if (qName.equals(ScanInfo.SCANINFO_TAG)) {
+		} else if (qName.equals(ScanInfo.SCANINFO_TAG)) {
 			fireEvent(scanInfo);
 			scanInfo = null;
-		}
-		if (qName.equals(Debugging.DEBUGGING_TAG)) {
+		} else if (qName.equals(Debugging.DEBUGGING_TAG)) {
 			fireEvent(debugging);
 			debugging = null;
-		}
-		if (qName.equals(Verbose.VERBOSE_TAG)) {
+		} else if (qName.equals(Verbose.VERBOSE_TAG)) {
 			fireEvent(verbose);
 			verbose = null;
-		}
-		if (qName.equals(Host.HOST_TAG)) {
+		} else if (qName.equals(Host.HOST_TAG)) {
 			fireEvent(host);
 			host = null;
-		}
-		if (qName.equals(Status.STATUS_TAG)) {
+		} else if (qName.equals(Status.STATUS_TAG)) {
 			fireEvent(status);
 			status = null;
-		}
-		if (qName.equals(Address.ADDRESS_TAG)) {
+		} else if (qName.equals(Address.ADDRESS_TAG)) {
 			fireEvent(address);
 			address = null;
-		}
-		if (qName.equals(Hostname.HOSTNAME_TAG)) {
+		} else if (qName.equals(Hostname.HOSTNAME_TAG)) {
 			fireEvent(hostname);
 			hostname = null;
-		}
-		if (qName.equals(Hostnames.HOSTNAMES_TAG)) {
+		} else if (qName.equals(Hostnames.HOSTNAMES_TAG)) {
 			fireEvent(hostnames);
 			hostnames = null;
-		}
-		if (qName.equals(Ports.PORTS_TAG)) {
+		} else if (qName.equals(Ports.PORTS_TAG)) {
 			fireEvent(ports);
 			ports = null;
-		}
-		if (qName.equals(Port.PORT_TAG)) {
+		} else if (qName.equals(Port.PORT_TAG)) {
 			fireEvent(port);
 			port = null;
-		}
-		if (qName.equals(State.STATE_TAG)) {
+		} else if (qName.equals(State.STATE_TAG)) {
 			fireEvent(state);
 			state = null;
-		}
-		if (qName.equals(Service.SERVICE_TAG)) {
+		} else if (qName.equals(Service.SERVICE_TAG)) {
 			fireEvent(service);
 			service = null;
-		}
-		if (qName.equals(Os.OS_TAG)) {
+		} else if (qName.equals(Os.OS_TAG)) {
 			fireEvent(os);
 			os = null;
-		}
-		if (qName.equals(PortUsed.PORT_USED_TAG)) {
+		} else if (qName.equals(PortUsed.PORT_USED_TAG)) {
 			fireEvent(portUsed);
 			portUsed = null;
-		}
-		if (qName.equals(OsClass.OSCLASS_TAG)) {
+		} else if (qName.equals(OsClass.OSCLASS_TAG)) {
 			fireEvent(osClass);
 			osClass = null;
-		}
-		if (qName.equals(OsMatch.OS_MATCH_TAG)) {
+		} else if (qName.equals(OsMatch.OS_MATCH_TAG)) {
 			fireEvent(osMatch);
 			osMatch = null;
-		}
-		if (qName.equals(Distance.DISTANCE_TAG)) {
+		} else if (qName.equals(Distance.DISTANCE_TAG)) {
 			fireEvent(distance);
 			distance = null;
-		}
-		if (qName.equals(TcpSequence.TCP_SEQUENCE_TAG)) {
+		} else if (qName.equals(TcpSequence.TCP_SEQUENCE_TAG)) {
 			fireEvent(tcpSequence);
 			tcpSequence = null;
-		}
-		if (qName.equals(TcpTsSequence.TCP_TS_SEQUENCE_TAG)) {
+		} else if (qName.equals(TcpTsSequence.TCP_TS_SEQUENCE_TAG)) {
 			fireEvent(tcpTsSequence);
 			tcpTsSequence = null;
-		}
-		if (qName.equals(Times.TIMES_TAG)) {
+		} else if (qName.equals(Times.TIMES_TAG)) {
 			fireEvent(times);
 			times = null;
-		}
-		if (qName.equals(Uptime.UPTIME_TAG)) {
+		} else if (qName.equals(Uptime.UPTIME_TAG)) {
 			fireEvent(uptime);
 			uptime = null;
-		}
-		if (qName.equals(RunStats.RUNSTATS_TAG)) {
+		} else if (qName.equals(RunStats.RUNSTATS_TAG)) {
 			fireEvent(runStats);
 			runStats = null;
-		}
-		if (qName.equals(Finished.FINISHED_TAG)) {
+		} else if (qName.equals(Finished.FINISHED_TAG)) {
 			fireEvent(finished);
 			finished = null;
-		}
-		if (qName.equals(Hosts.HOSTS_TAG)) {
+		} else if (qName.equals(Hosts.HOSTS_TAG)) {
 			fireEvent(hosts);
 			hosts = null;
-		}
-		if (qName.equals(Cpe.CPE_ATTR)) {
+		} else if (qName.equals(Cpe.CPE_ATTR)) {
 			fireEvent(cpe);
 			cpe = null;
-		}
-		if (qName.equals(Trace.TRACE_TAG)) {
+		} else if (qName.equals(Trace.TRACE_TAG)) {
 			fireEvent(trace);
 			trace = null;
-		}
-		if (qName.equals(Hop.HOP_TAG)) {
+		} else if (qName.equals(Hop.HOP_TAG)) {
 			fireEvent(hop);
 			hop = null;
-		}
-		if (qName.equals(HostScript.TAG)) {
+		} else if (qName.equals(HostScript.TAG)) {
 			fireEvent(hostScript);
 			hostScript = null;
-		}
-		if (qName.equals(Script.TAG)) {
+		} else if (qName.equals(Script.TAG)) {
 			if (this.hostScript != null || this.port != null) {
 				fireEvent(script);
 				script = null;
 			}
-		}
-		if (qName.equals(Script.ELEMTAG)) {
+		} else if (qName.equals(Script.ELEMTAG)) {
 			elemkey = null;
 		}
 	}

--- a/src/main/java/org/nmap4j/parser/NMapXmlHandler.java
+++ b/src/main/java/org/nmap4j/parser/NMapXmlHandler.java
@@ -128,7 +128,7 @@ public class NMapXmlHandler extends DefaultHandler {
 
 	private void fireEvent(Object payload) {
 		if(payload==null){
-			throw new InternalError("Nmap XML error, end tag with no beginning?");
+			throw new RuntimeException("Nmap XML error, end tag with no beginning?");
 		}
 		ParserEvent event = new ParserEvent(this, payload);
 		if (listeners != null && listeners.size() > 0) {
@@ -170,91 +170,91 @@ public class NMapXmlHandler extends DefaultHandler {
 			nmapRun = runHandler.createNMapRun(attributes);
 		} else if (qName.equals(ScanInfo.SCANINFO_TAG)) {
 			if(scanInfo!=null){
-				throw new InternalError( nestedTagErrorMsg(qName) );
+				throw new RuntimeException( nestedTagErrorMsg(qName) );
 			}
 			scanInfo = runHandler.createScanInfo(attributes);
 			nmapRun.setScanInfo(scanInfo);
 		} else if (qName.equals(Debugging.DEBUGGING_TAG)) {
 			if(debugging!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			debugging = runHandler.createDebugging(attributes);
 			nmapRun.setDebugging(debugging);
 		} else if (qName.equals(Verbose.VERBOSE_TAG)) {
 			if(verbose!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			verbose = runHandler.createVerbose(attributes);
 			nmapRun.setVerbose(verbose);
 		} else if (qName.equals(Host.HOST_TAG)) {
 			if(host!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			host = runHandler.createHost(attributes);
 			nmapRun.addHost(host);
 		} else if (qName.equals(Status.STATUS_TAG)) {
 			if(status!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			status = runHandler.createStatus(attributes);
 			host.setStatus(status);
 		} else if (qName.equals(Address.ADDRESS_TAG)) {
 			if(address!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			address = runHandler.createAddress(attributes);
 			host.addAddress(address);
 		} else if (qName.equals(Hostnames.HOSTNAMES_TAG)) {
 			if(hostnames!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			hostnames = runHandler.createHostnames(attributes);
 			host.setHostnames(hostnames);
 		} else if (qName.equals(Hostname.HOSTNAME_TAG)) {
 			if(hostname!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			hostname = runHandler.createHostname(attributes);
 			hostnames.setHostname(hostname);
 		} else if (qName.equals(Ports.PORTS_TAG)) {
 			if(ports!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			ports = runHandler.createPorts(attributes);
 			host.setPorts(ports);
 		} else if (qName.equals(Port.PORT_TAG)) {
 			if(port!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			port = runHandler.createPort(attributes);
 			ports.addPort(port);
 		} else if (qName.equals(State.STATE_TAG)) {
 			if(state!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			state = runHandler.createState(attributes);
 			port.setState(state);
 		} else if (qName.equals(Service.SERVICE_TAG)) {
 			if(service!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			service = runHandler.createService(attributes);
 			port.setService(service);
 		} else if (qName.equals(Os.OS_TAG)) {
 			if(os!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			os = runHandler.createOs(attributes);
 			host.setOs(os);
 		} else if (qName.equals(PortUsed.PORT_USED_TAG)) {
 			if(portUsed!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			portUsed = runHandler.createPortUsed(attributes);
 			os.addPortUsed(portUsed);
 		} else if (qName.equals(OsClass.OSCLASS_TAG)) {
 			if(osClass!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			osClass = runHandler.createOsClass(attributes);
 			if(osMatch==null ){
@@ -264,55 +264,55 @@ public class NMapXmlHandler extends DefaultHandler {
 			}
 		} else if (qName.equals(OsMatch.OS_MATCH_TAG)) {
 			if(osMatch!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			osMatch = runHandler.createOsMatch(attributes);
 			os.addOsMatch(osMatch);
 		} else if (qName.equals(Distance.DISTANCE_TAG)) {
 			if(distance!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			distance = runHandler.createDistance(attributes);
 			host.setDistance(distance);
 		} else if (qName.equals(TcpSequence.TCP_SEQUENCE_TAG)) {
 			if(tcpSequence!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			tcpSequence = runHandler.createTcpSequence(attributes);
 			host.setTcpSequence(tcpSequence);
 		} else if (qName.equals(TcpTsSequence.TCP_TS_SEQUENCE_TAG)) {
 			if(tcpTsSequence!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			tcpTsSequence = runHandler.createTcpTsSequence(attributes);
 			host.setTcpTsSequence(tcpTsSequence);
 		} else if (qName.equals(Times.TIMES_TAG)) {
 			if(times!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			times = runHandler.createTimes(attributes);
 			host.setTimes(times);
 		} else if (qName.equals(Uptime.UPTIME_TAG)) {
 			if(uptime!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			uptime = runHandler.createUptime(attributes);
 			host.setUptime(uptime);
 		} else if (qName.equals(RunStats.RUNSTATS_TAG)) {
 			if(runStats!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			runStats = runHandler.createRunStats(attributes);
 			nmapRun.setRunStats(runStats);
 		} else if (qName.equals(Finished.FINISHED_TAG)) {
 			if(finished!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			finished = runHandler.createFinished(attributes);
 			runStats.setFinished(finished);
 		} else if (qName.equals(Hosts.HOSTS_TAG)) {
 			if(hosts!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			hosts = runHandler.createHosts(attributes);
 			runStats.setHosts(hosts);
@@ -326,19 +326,19 @@ public class NMapXmlHandler extends DefaultHandler {
 			}
 		} else if (qName.equals(Trace.TRACE_TAG)) {
 			if(trace!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			trace = runHandler.createTrace(attributes);
 			host.setTrace(trace);
 		} else if (qName.equals(Hop.HOP_TAG)) {
 			if(hop!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			hop = runHandler.createHop(attributes);
 			trace.addHop(hop);
 		} else if (qName.equals(HostScript.TAG)) {
 			if(hostScript!=null){
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			hostScript = runHandler.createHostScript(attributes);
 			host.setHostScript(this.hostScript);
@@ -359,7 +359,7 @@ public class NMapXmlHandler extends DefaultHandler {
 			}
 		} else if (qName.equals(Script.ELEMTAG)) {
 			if (this.elemkey != null) {
-				throw new InternalError( nestedTagErrorMsg(qName));
+				throw new RuntimeException( nestedTagErrorMsg(qName));
 			}
 			// sometimes this.script == null in practice so I will not check it. Not sure if it should be.
 			this.elemkey = attributes.getValue("key");

--- a/src/main/java/org/nmap4j/parser/NMapXmlHandler.java
+++ b/src/main/java/org/nmap4j/parser/NMapXmlHandler.java
@@ -128,7 +128,7 @@ public class NMapXmlHandler extends DefaultHandler {
 
 	private void fireEvent(Object payload) {
 		if(payload==null){
-			throw new RuntimeException("Nmap XML error, end tag with no beginning?");
+			throw new SAXEndTagError("Nmap XML error, end tag with no beginning?");
 		}
 		ParserEvent event = new ParserEvent(this, payload);
 		if (listeners != null && listeners.size() > 0) {
@@ -170,91 +170,91 @@ public class NMapXmlHandler extends DefaultHandler {
 			nmapRun = runHandler.createNMapRun(attributes);
 		} else if (qName.equals(ScanInfo.SCANINFO_TAG)) {
 			if(scanInfo!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName) );
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName) );
 			}
 			scanInfo = runHandler.createScanInfo(attributes);
 			nmapRun.setScanInfo(scanInfo);
 		} else if (qName.equals(Debugging.DEBUGGING_TAG)) {
 			if(debugging!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			debugging = runHandler.createDebugging(attributes);
 			nmapRun.setDebugging(debugging);
 		} else if (qName.equals(Verbose.VERBOSE_TAG)) {
 			if(verbose!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			verbose = runHandler.createVerbose(attributes);
 			nmapRun.setVerbose(verbose);
 		} else if (qName.equals(Host.HOST_TAG)) {
 			if(host!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			host = runHandler.createHost(attributes);
 			nmapRun.addHost(host);
 		} else if (qName.equals(Status.STATUS_TAG)) {
 			if(status!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			status = runHandler.createStatus(attributes);
 			host.setStatus(status);
 		} else if (qName.equals(Address.ADDRESS_TAG)) {
 			if(address!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			address = runHandler.createAddress(attributes);
 			host.addAddress(address);
 		} else if (qName.equals(Hostnames.HOSTNAMES_TAG)) {
 			if(hostnames!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			hostnames = runHandler.createHostnames(attributes);
 			host.setHostnames(hostnames);
 		} else if (qName.equals(Hostname.HOSTNAME_TAG)) {
 			if(hostname!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			hostname = runHandler.createHostname(attributes);
 			hostnames.setHostname(hostname);
 		} else if (qName.equals(Ports.PORTS_TAG)) {
 			if(ports!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			ports = runHandler.createPorts(attributes);
 			host.setPorts(ports);
 		} else if (qName.equals(Port.PORT_TAG)) {
 			if(port!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			port = runHandler.createPort(attributes);
 			ports.addPort(port);
 		} else if (qName.equals(State.STATE_TAG)) {
 			if(state!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			state = runHandler.createState(attributes);
 			port.setState(state);
 		} else if (qName.equals(Service.SERVICE_TAG)) {
 			if(service!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			service = runHandler.createService(attributes);
 			port.setService(service);
 		} else if (qName.equals(Os.OS_TAG)) {
 			if(os!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			os = runHandler.createOs(attributes);
 			host.setOs(os);
 		} else if (qName.equals(PortUsed.PORT_USED_TAG)) {
 			if(portUsed!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			portUsed = runHandler.createPortUsed(attributes);
 			os.addPortUsed(portUsed);
 		} else if (qName.equals(OsClass.OSCLASS_TAG)) {
 			if(osClass!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			osClass = runHandler.createOsClass(attributes);
 			if(osMatch==null ){
@@ -264,55 +264,55 @@ public class NMapXmlHandler extends DefaultHandler {
 			}
 		} else if (qName.equals(OsMatch.OS_MATCH_TAG)) {
 			if(osMatch!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			osMatch = runHandler.createOsMatch(attributes);
 			os.addOsMatch(osMatch);
 		} else if (qName.equals(Distance.DISTANCE_TAG)) {
 			if(distance!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			distance = runHandler.createDistance(attributes);
 			host.setDistance(distance);
 		} else if (qName.equals(TcpSequence.TCP_SEQUENCE_TAG)) {
 			if(tcpSequence!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			tcpSequence = runHandler.createTcpSequence(attributes);
 			host.setTcpSequence(tcpSequence);
 		} else if (qName.equals(TcpTsSequence.TCP_TS_SEQUENCE_TAG)) {
 			if(tcpTsSequence!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			tcpTsSequence = runHandler.createTcpTsSequence(attributes);
 			host.setTcpTsSequence(tcpTsSequence);
 		} else if (qName.equals(Times.TIMES_TAG)) {
 			if(times!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			times = runHandler.createTimes(attributes);
 			host.setTimes(times);
 		} else if (qName.equals(Uptime.UPTIME_TAG)) {
 			if(uptime!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			uptime = runHandler.createUptime(attributes);
 			host.setUptime(uptime);
 		} else if (qName.equals(RunStats.RUNSTATS_TAG)) {
 			if(runStats!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			runStats = runHandler.createRunStats(attributes);
 			nmapRun.setRunStats(runStats);
 		} else if (qName.equals(Finished.FINISHED_TAG)) {
 			if(finished!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			finished = runHandler.createFinished(attributes);
 			runStats.setFinished(finished);
 		} else if (qName.equals(Hosts.HOSTS_TAG)) {
 			if(hosts!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			hosts = runHandler.createHosts(attributes);
 			runStats.setHosts(hosts);
@@ -326,19 +326,19 @@ public class NMapXmlHandler extends DefaultHandler {
 			}
 		} else if (qName.equals(Trace.TRACE_TAG)) {
 			if(trace!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			trace = runHandler.createTrace(attributes);
 			host.setTrace(trace);
 		} else if (qName.equals(Hop.HOP_TAG)) {
 			if(hop!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			hop = runHandler.createHop(attributes);
 			trace.addHop(hop);
 		} else if (qName.equals(HostScript.TAG)) {
 			if(hostScript!=null){
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			hostScript = runHandler.createHostScript(attributes);
 			host.setHostScript(this.hostScript);
@@ -359,7 +359,7 @@ public class NMapXmlHandler extends DefaultHandler {
 			}
 		} else if (qName.equals(Script.ELEMTAG)) {
 			if (this.elemkey != null) {
-				throw new RuntimeException( nestedTagErrorMsg(qName));
+				throw new SaxNestedTagError( nestedTagErrorMsg(qName));
 			}
 			// sometimes this.script == null in practice so I will not check it. Not sure if it should be.
 			this.elemkey = attributes.getValue("key");

--- a/src/main/java/org/nmap4j/parser/NMapXmlHandler.java
+++ b/src/main/java/org/nmap4j/parser/NMapXmlHandler.java
@@ -163,98 +163,174 @@ public class NMapXmlHandler extends DefaultHandler {
 			nmapRun = runHandler.createNMapRun(attributes);
 		}
 		if (qName.equals(ScanInfo.SCANINFO_TAG)) {
+			if(scanInfo!=null){
+				throw new RuntimeException(  );
+			}
 			scanInfo = runHandler.createScanInfo(attributes);
 			nmapRun.setScanInfo(scanInfo);
 		}
 		if (qName.equals(Debugging.DEBUGGING_TAG)) {
+			if(debugging!=null){
+				throw new RuntimeException(  );
+			}
 			debugging = runHandler.createDebugging(attributes);
 			nmapRun.setDebugging(debugging);
 		}
 		if (qName.equals(Verbose.VERBOSE_TAG)) {
+			if(verbose!=null){
+				throw new RuntimeException(  );
+			}
 			verbose = runHandler.createVerbose(attributes);
 			nmapRun.setVerbose(verbose);
 		}
 		if (qName.equals(Host.HOST_TAG)) {
+			if(host!=null){
+				throw new RuntimeException(  );
+			}
 			host = runHandler.createHost(attributes);
 			nmapRun.addHost(host);
 		}
 		if (qName.equals(Status.STATUS_TAG)) {
+			if(status!=null){
+				throw new RuntimeException(  );
+			}
 			status = runHandler.createStatus(attributes);
 			host.setStatus(status);
 		}
 		if (qName.equals(Address.ADDRESS_TAG)) {
+			if(address!=null){
+				throw new RuntimeException(  );
+			}
 			address = runHandler.createAddress(attributes);
 			host.addAddress(address);
 		}
 		if (qName.equals(Hostnames.HOSTNAMES_TAG)) {
+			if(hostnames!=null){
+				throw new RuntimeException(  );
+			}
 			hostnames = runHandler.createHostnames(attributes);
 			host.setHostnames(hostnames);
 		}
 		if (qName.equals(Hostname.HOSTNAME_TAG)) {
+			if(hostname!=null){
+				throw new RuntimeException(  );
+			}
 			hostname = runHandler.createHostname(attributes);
 			hostnames.setHostname(hostname);
 		}
 		if (qName.equals(Ports.PORTS_TAG)) {
+			if(ports!=null){
+				throw new RuntimeException(  );
+			}
 			ports = runHandler.createPorts(attributes);
 			host.setPorts(ports);
 		}
 		if (qName.equals(Port.PORT_TAG)) {
+			if(port!=null){
+				throw new RuntimeException(  );
+			}
 			port = runHandler.createPort(attributes);
 			ports.addPort(port);
 		}
 		if (qName.equals(State.STATE_TAG)) {
+			if(state!=null){
+				throw new RuntimeException(  );
+			}
 			state = runHandler.createState(attributes);
 			port.setState(state);
 		}
 		if (qName.equals(Service.SERVICE_TAG)) {
+			if(service!=null){
+				throw new RuntimeException(  );
+			}
 			service = runHandler.createService(attributes);
 			port.setService(service);
 		}
 		if (qName.equals(Os.OS_TAG)) {
+			if(os!=null){
+				throw new RuntimeException(  );
+			}
 			os = runHandler.createOs(attributes);
 			host.setOs(os);
 		}
 		if (qName.equals(PortUsed.PORT_USED_TAG)) {
+			if(portUsed!=null){
+				throw new RuntimeException(  );
+			}
 			portUsed = runHandler.createPortUsed(attributes);
 			os.addPortUsed(portUsed);
 		}
 		if (qName.equals(OsClass.OSCLASS_TAG)) {
+			if(osClass!=null){
+				throw new RuntimeException(  );
+			}
 			osClass = runHandler.createOsClass(attributes);
-			os.addOsClass(osClass);
+			if(osMatch==null ){
+				os.addOsClass( osClass );
+			}else  {
+				osMatch.addOsClass( osClass );
+			}
 		}
 		if (qName.equals(OsMatch.OS_MATCH_TAG)) {
+			if(osMatch!=null){
+				throw new RuntimeException(  );
+			}
 			osMatch = runHandler.createOsMatch(attributes);
 			os.addOsMatch(osMatch);
 		}
 		if (qName.equals(Distance.DISTANCE_TAG)) {
+			if(distance!=null){
+				throw new RuntimeException(  );
+			}
 			distance = runHandler.createDistance(attributes);
 			host.setDistance(distance);
 		}
 		if (qName.equals(TcpSequence.TCP_SEQUENCE_TAG)) {
+			if(tcpSequence!=null){
+				throw new RuntimeException(  );
+			}
 			tcpSequence = runHandler.createTcpSequence(attributes);
 			host.setTcpSequence(tcpSequence);
 		}
 		if (qName.equals(TcpTsSequence.TCP_TS_SEQUENCE_TAG)) {
+			if(tcpTsSequence!=null){
+				throw new RuntimeException(  );
+			}
 			tcpTsSequence = runHandler.createTcpTsSequence(attributes);
 			host.setTcpTsSequence(tcpTsSequence);
 		}
 		if (qName.equals(Times.TIMES_TAG)) {
+			if(times!=null){
+				throw new RuntimeException(  );
+			}
 			times = runHandler.createTimes(attributes);
 			host.setTimes(times);
 		}
 		if (qName.equals(Uptime.UPTIME_TAG)) {
+			if(uptime!=null){
+				throw new RuntimeException(  );
+			}
 			uptime = runHandler.createUptime(attributes);
 			host.setUptime(uptime);
 		}
 		if (qName.equals(RunStats.RUNSTATS_TAG)) {
+			if(runStats!=null){
+				throw new RuntimeException(  );
+			}
 			runStats = runHandler.createRunStats(attributes);
 			nmapRun.setRunStats(runStats);
 		}
 		if (qName.equals(Finished.FINISHED_TAG)) {
+			if(finished!=null){
+				throw new RuntimeException(  );
+			}
 			finished = runHandler.createFinished(attributes);
 			runStats.setFinished(finished);
 		}
 		if (qName.equals(Hosts.HOSTS_TAG)) {
+			if(hosts!=null){
+				throw new RuntimeException(  );
+			}
 			hosts = runHandler.createHosts(attributes);
 			runStats.setHosts(hosts);
 		}
@@ -268,17 +344,26 @@ public class NMapXmlHandler extends DefaultHandler {
 			}
 		}
 		if (qName.equals(Trace.TRACE_TAG)) {
+			if(trace!=null){
+				throw new RuntimeException(  );
+			}
 			trace = runHandler.createTrace(attributes);
 			host.setTrace(trace);
 		}
 		if (qName.equals(Hop.HOP_TAG)) {
+			if(hop!=null){
+				throw new RuntimeException(  );
+			}
 			hop = runHandler.createHop(attributes);
 			trace.addHop(hop);
 		}
 
 		if (qName.equals(HostScript.TAG)) {
-			this.hostScript = runHandler.createHostScript(attributes);
-			this.host.setHostScript(this.hostScript);
+			if(hostScript!=null){
+				throw new RuntimeException(  );
+			}
+			hostScript = runHandler.createHostScript(attributes);
+			host.setHostScript(this.hostScript);
 		}
 		if (qName.equals(Script.TAG)) {
 			if (this.hostScript != null) {
@@ -288,6 +373,12 @@ public class NMapXmlHandler extends DefaultHandler {
 			} else if (this.port != null) {
 				this.script = runHandler.createScript(attributes);
 				this.port.addScript(this.script);
+			}else{
+				if("postscript".equals( previousQName) ){
+					// puede ser, no esta implementado
+				}else{
+					throw new RuntimeException(  );
+				}
 			}
 		}
 		if (qName.equals(Script.ELEMTAG)) {

--- a/src/main/java/org/nmap4j/parser/OnePassParser.java
+++ b/src/main/java/org/nmap4j/parser/OnePassParser.java
@@ -83,8 +83,8 @@ public class OnePassParser implements NMap4JParserEventListener {
 	}
 	
 	public NMapRun parse( String input, int type  ) {
-		
-		NMapXmlHandler.addListener( this ) ;
+
+		nmxh.addListener( this ) ;
 		
 		SAXParserFactory spf = SAXParserFactory.newInstance();
 	    try {
@@ -112,8 +112,8 @@ public class OnePassParser implements NMap4JParserEventListener {
 	    }catch (IOException ie) {
 	      ie.printStackTrace();
 	    }
-	    
-	    NMapXmlHandler.removeListener( this ) ;
+
+		nmxh.removeListener( this ) ;
 	    
 		return nmapRun ;
 	}
@@ -126,11 +126,11 @@ public class OnePassParser implements NMap4JParserEventListener {
 	}
 	
 	public void addListener(NMap4JParserEventListener aListener ) {
-		NMapXmlHandler.addListener( aListener ) ; 
+		nmxh.addListener( aListener ) ;
  	}
 	
 	public void removeListener( NMap4JParserEventListener aListener ) {
-		NMapXmlHandler.removeListener( aListener ) ;
+		nmxh.removeListener( aListener ) ;
 	}
 	
 }

--- a/src/main/java/org/nmap4j/parser/SAXEndTagError.java
+++ b/src/main/java/org/nmap4j/parser/SAXEndTagError.java
@@ -1,0 +1,7 @@
+package org.nmap4j.parser;
+
+public class SAXEndTagError extends RuntimeException {
+	public SAXEndTagError(String s) {
+		super(s);
+	}
+}

--- a/src/main/java/org/nmap4j/parser/SaxNestedTagError.java
+++ b/src/main/java/org/nmap4j/parser/SaxNestedTagError.java
@@ -1,0 +1,7 @@
+package org.nmap4j.parser;
+
+public class SaxNestedTagError extends RuntimeException {
+	public SaxNestedTagError(String s) {
+		super(s);
+	}
+}

--- a/src/test/java/org/nmap4j/parsers/NMapXmlHandlerTest.java
+++ b/src/test/java/org/nmap4j/parsers/NMapXmlHandlerTest.java
@@ -19,7 +19,7 @@ import java.io.InputStream;
 public class NMapXmlHandlerTest implements IConstants {
 
 	@Test
-	public void basicTest() {
+	public void basicTest() throws ParserConfigurationException, SAXException, IOException {
 
 
 		INMapRunHandler nmrh = new NMapRunHandlerImpl();
@@ -30,24 +30,17 @@ public class NMapXmlHandlerTest implements IConstants {
 		NMapXmlHandler.addListener( listener );
 
 		SAXParserFactory spf = SAXParserFactory.newInstance();
-		try {
 
-			//get a new instance of parser
-			SAXParser sp = spf.newSAXParser();
 
-			// get the ms-vscan.xml as a stream
-			InputStream in = getClass().getClassLoader().getResourceAsStream( NmapDataSamples.fileName );
+		//get a new instance of parser
+		SAXParser sp = spf.newSAXParser();
 
-			//parse the file and also register this class for call backs
-			sp.parse( in, nmxh );
+		// get the ms-vscan.xml as a stream
+		InputStream in = getClass().getClassLoader().getResourceAsStream( NmapDataSamples.fileName );
 
-		} catch (SAXException se) {
-			se.printStackTrace();
-		} catch (ParserConfigurationException pce) {
-			pce.printStackTrace();
-		} catch (IOException ie) {
-			ie.printStackTrace();
-		}
+		//parse the file and also register this class for call backs
+		sp.parse( in, nmxh );
+
 
 		System.out.println( "\n\n exec time: " + nmxh.getExecTime() + "ms" );
 	}

--- a/src/test/java/org/nmap4j/parsers/NMapXmlHandlerTest.java
+++ b/src/test/java/org/nmap4j/parsers/NMapXmlHandlerTest.java
@@ -27,7 +27,7 @@ public class NMapXmlHandlerTest implements IConstants {
 
 		TestListener listener = new TestListener();
 
-		NMapXmlHandler.addListener( listener );
+		nmxh.addListener( listener );
 
 		SAXParserFactory spf = SAXParserFactory.newInstance();
 
@@ -36,13 +36,14 @@ public class NMapXmlHandlerTest implements IConstants {
 		SAXParser sp = spf.newSAXParser();
 
 		// get the ms-vscan.xml as a stream
-		InputStream in = getClass().getClassLoader().getResourceAsStream( NmapDataSamples.fileName );
+		try(InputStream in = getClass().getClassLoader().getResourceAsStream( NmapDataSamples.fileName )) {
 
-		//parse the file and also register this class for call backs
-		sp.parse( in, nmxh );
-
+			//parse the file and also register this class for call backs
+			sp.parse( in, nmxh );
+		}
 
 		System.out.println( "\n\n exec time: " + nmxh.getExecTime() + "ms" );
+
 	}
 
 

--- a/src/test/java/org/nmap4j/parsers/OnePassParserTest.java
+++ b/src/test/java/org/nmap4j/parsers/OnePassParserTest.java
@@ -57,23 +57,18 @@ public class OnePassParserTest implements IConstants {
     }
 
     @Test
-    public void testOnePassWithSMBOutput() {
+    public void testOnePassWithSMBOutput() throws IOException {
 
 
         OnePassParser opp = new OnePassParser();
 
         NMapRun nmapRun = null;
-        try {
-            InputStream is = getClass().getClassLoader().getResourceAsStream(NmapDataSamples.smbFileName);
 
-            String fileAsString = IOUtils.toString(is);
+		InputStream is = getClass().getClassLoader().getResourceAsStream(NmapDataSamples.smbFileName);
 
-            nmapRun = opp.parse(fileAsString, OnePassParser.STRING_INPUT);
+		String fileAsString = IOUtils.toString(is);
 
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+		nmapRun = opp.parse(fileAsString, OnePassParser.STRING_INPUT);
 
         if (nmapRun != null) {
             System.out.println("hosts count: " + nmapRun.getHosts().size());
@@ -84,7 +79,7 @@ public class OnePassParserTest implements IConstants {
 
 
     @Test
-    public void testForPresenceOfCpeData() {
+    public void testForPresenceOfCpeData() throws IOException {
 
         System.out.println("start");
 
@@ -92,47 +87,45 @@ public class OnePassParserTest implements IConstants {
         OnePassParser opp = new OnePassParser();
 
         NMapRun nmapRun = null;
-        try {
-            InputStream is = getClass().getClassLoader().getResourceAsStream(NmapDataSamples.smbFileName);
 
-            String fileAsString = IOUtils.toString(is);
+		InputStream is = getClass().getClassLoader().getResourceAsStream(NmapDataSamples.smbFileName);
 
-            nmapRun = opp.parse(fileAsString, OnePassParser.STRING_INPUT);
+		String fileAsString = IOUtils.toString(is);
 
-            ArrayList<Host> hosts = nmapRun.getHosts();
+		nmapRun = opp.parse(fileAsString, OnePassParser.STRING_INPUT);
 
-            boolean foundAtLeastOneNotNullCpeObj = false;
+		ArrayList<Host> hosts = nmapRun.getHosts();
 
-            for (Host host : hosts) {
-                if (host.getOs() != null) {
-                    ArrayList<OsMatch> osMatches = host.getOs().getOsMatches();
-                    for(OsMatch osMatch:osMatches){
-                        if (osMatch.getOsClasses() != null) {
-                            ArrayList<OsClass> osClasses = osMatch.getOsClasses();
-                            for (OsClass osClass : osClasses) {
-                                ArrayList<Cpe> cpeData = osClass.getCpe();
-                                for (Cpe cpe : cpeData) {
-                                    if (cpe != null) {
-                                        if (cpe.getCpeData() != null) {
-                                            System.out.println(cpe.getCpeData());
-                                            foundAtLeastOneNotNullCpeObj = true;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+		boolean foundAtLeastOneNotNullCpeObj = false;
 
-            if (!foundAtLeastOneNotNullCpeObj) {
-                fail();
-            }
+		for (Host host : hosts) {
+			if (host.getOs() != null) {
+				ArrayList<OsMatch> osMatches = host.getOs().getOsMatches();
+				for(OsMatch osMatch:osMatches){
+					if (osMatch.getOsClasses() != null) {
+						ArrayList<OsClass> osClasses = osMatch.getOsClasses();
+						for (OsClass osClass : osClasses) {
+							ArrayList<Cpe> cpeData = osClass.getCpe();
+							for (Cpe cpe : cpeData) {
+								if (cpe != null) {
+									if (cpe.getCpeData() != null) {
+										System.out.println(cpe.getCpeData());
+										foundAtLeastOneNotNullCpeObj = true;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if (!foundAtLeastOneNotNullCpeObj) {
+			fail();
+		}
 
 
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+
 
         if (nmapRun != null) {
             System.out.println("hosts count: " + nmapRun.getHosts().size());
@@ -173,7 +166,7 @@ public class OnePassParserTest implements IConstants {
     }
 
     @Test
-    public void testAddingListener() {
+    public void testAddingListener() throws IOException {
         System.out.println("start");
 
 
@@ -183,19 +176,14 @@ public class OnePassParserTest implements IConstants {
 
         HostListener simpleListener = new HostListener();
 
-        try {
-            InputStream is = getClass().getClassLoader().getResourceAsStream(NmapDataSamples.smbFileName);
+		InputStream is = getClass().getClassLoader().getResourceAsStream(NmapDataSamples.smbFileName);
 
-            String fileAsString = IOUtils.toString(is);
+		String fileAsString = IOUtils.toString(is);
 
-            opp.addListener(simpleListener);
-            nmapRun = opp.parse(fileAsString, OnePassParser.STRING_INPUT);
+		opp.addListener(simpleListener);
+		nmapRun = opp.parse(fileAsString, OnePassParser.STRING_INPUT);
 
-            ArrayList<Host> hosts = nmapRun.getHosts();
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+		ArrayList<Host> hosts = nmapRun.getHosts();
 
         if (nmapRun != null) {
             if (nmapRun.getHosts().size() != simpleListener.getHostCount()) {

--- a/src/test/java/org/nmap4j/parsers/OnePassParserTest.java
+++ b/src/test/java/org/nmap4j/parsers/OnePassParserTest.java
@@ -14,6 +14,7 @@ import org.nmap4j.core.scans.ParameterValidationFailureException;
 import org.nmap4j.data.NMapRun;
 import org.nmap4j.data.host.Cpe;
 import org.nmap4j.data.host.os.OsClass;
+import org.nmap4j.data.host.os.OsMatch;
 import org.nmap4j.data.host.scripts.HostScript;
 import org.nmap4j.data.host.scripts.Script;
 import org.nmap4j.data.nmaprun.Host;
@@ -104,15 +105,18 @@ public class OnePassParserTest implements IConstants {
 
             for (Host host : hosts) {
                 if (host.getOs() != null) {
-                    if (host.getOs().getOsClasses() != null) {
-                        ArrayList<OsClass> osClasses = host.getOs().getOsClasses();
-                        for (OsClass osClass : osClasses) {
-                            ArrayList<Cpe> cpeData = osClass.getCpe();
-                            for (Cpe cpe : cpeData) {
-                                if (cpe != null) {
-                                    if (cpe.getCpeData() != null) {
-                                        System.out.println(cpe.getCpeData());
-                                        foundAtLeastOneNotNullCpeObj = true;
+                    ArrayList<OsMatch> osMatches = host.getOs().getOsMatches();
+                    for(OsMatch osMatch:osMatches){
+                        if (osMatch.getOsClasses() != null) {
+                            ArrayList<OsClass> osClasses = osMatch.getOsClasses();
+                            for (OsClass osClass : osClasses) {
+                                ArrayList<Cpe> cpeData = osClass.getCpe();
+                                for (Cpe cpe : cpeData) {
+                                    if (cpe != null) {
+                                        if (cpe.getCpeData() != null) {
+                                            System.out.println(cpe.getCpeData());
+                                            foundAtLeastOneNotNullCpeObj = true;
+                                        }
                                     }
                                 }
                             }

--- a/src/test/java/org/nmap4j/parsers/OnePassParserTest.java
+++ b/src/test/java/org/nmap4j/parsers/OnePassParserTest.java
@@ -34,19 +34,17 @@ import static org.junit.Assert.fail;
 public class OnePassParserTest implements IConstants {
 
 
-    public void testOnePass() {
+    public void testOnePass() throws IOException {
         OnePassParser opp = new OnePassParser();
 
         NMapRun nmapRun = null;
-        try {
-            InputStream is = getClass().getClassLoader().getResourceAsStream(NmapDataSamples.fileName);
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(NmapDataSamples.fileName)){
+
 
             String fileAsString = IOUtils.toString(is);
 
             nmapRun = opp.parse(fileAsString, OnePassParser.STRING_INPUT);
 
-        } catch (IOException e) {
-            e.printStackTrace();
         }
 
         if (nmapRun != null) {
@@ -62,19 +60,18 @@ public class OnePassParserTest implements IConstants {
 
         OnePassParser opp = new OnePassParser();
 
-        NMapRun nmapRun = null;
+		try(InputStream is = getClass().getClassLoader().getResourceAsStream(NmapDataSamples.smbFileName)) {
 
-		InputStream is = getClass().getClassLoader().getResourceAsStream(NmapDataSamples.smbFileName);
+			String fileAsString = IOUtils.toString( is );
 
-		String fileAsString = IOUtils.toString(is);
+			NMapRun nmapRun = opp.parse( fileAsString, OnePassParser.STRING_INPUT );
 
-		nmapRun = opp.parse(fileAsString, OnePassParser.STRING_INPUT);
-
-        if (nmapRun != null) {
-            System.out.println("hosts count: " + nmapRun.getHosts().size());
-        } else {
-            System.out.println("nmapRun is null");
-        }
+			if (nmapRun != null) {
+				System.out.println( "hosts count: " + nmapRun.getHosts().size() );
+			} else {
+				System.out.println( "nmapRun is null" );
+			}
+		}
     }
 
 
@@ -88,29 +85,30 @@ public class OnePassParserTest implements IConstants {
 
         NMapRun nmapRun = null;
 
-		InputStream is = getClass().getClassLoader().getResourceAsStream(NmapDataSamples.smbFileName);
+		try(InputStream is = getClass().getClassLoader().getResourceAsStream(NmapDataSamples.smbFileName)) {
 
-		String fileAsString = IOUtils.toString(is);
+			String fileAsString = IOUtils.toString( is );
 
-		nmapRun = opp.parse(fileAsString, OnePassParser.STRING_INPUT);
+			nmapRun = opp.parse( fileAsString, OnePassParser.STRING_INPUT );
 
-		ArrayList<Host> hosts = nmapRun.getHosts();
+			ArrayList<Host> hosts = nmapRun.getHosts();
 
-		boolean foundAtLeastOneNotNullCpeObj = false;
+			boolean foundAtLeastOneNotNullCpeObj = false;
 
-		for (Host host : hosts) {
-			if (host.getOs() != null) {
-				ArrayList<OsMatch> osMatches = host.getOs().getOsMatches();
-				for(OsMatch osMatch:osMatches){
-					if (osMatch.getOsClasses() != null) {
-						ArrayList<OsClass> osClasses = osMatch.getOsClasses();
-						for (OsClass osClass : osClasses) {
-							ArrayList<Cpe> cpeData = osClass.getCpe();
-							for (Cpe cpe : cpeData) {
-								if (cpe != null) {
-									if (cpe.getCpeData() != null) {
-										System.out.println(cpe.getCpeData());
-										foundAtLeastOneNotNullCpeObj = true;
+			for (Host host : hosts) {
+				if (host.getOs() != null) {
+					ArrayList<OsMatch> osMatches = host.getOs().getOsMatches();
+					for (OsMatch osMatch : osMatches) {
+						if (osMatch.getOsClasses() != null) {
+							ArrayList<OsClass> osClasses = osMatch.getOsClasses();
+							for (OsClass osClass : osClasses) {
+								ArrayList<Cpe> cpeData = osClass.getCpe();
+								for (Cpe cpe : cpeData) {
+									if (cpe != null) {
+										if (cpe.getCpeData() != null) {
+											System.out.println( cpe.getCpeData() );
+											foundAtLeastOneNotNullCpeObj = true;
+										}
 									}
 								}
 							}
@@ -118,20 +116,19 @@ public class OnePassParserTest implements IConstants {
 					}
 				}
 			}
+
+			if (!foundAtLeastOneNotNullCpeObj) {
+				fail();
+			}
+
+
+			if (nmapRun != null) {
+				System.out.println( "hosts count: " + nmapRun.getHosts().size() );
+			} else {
+				System.out.println( "nmapRun is null" );
+			}
 		}
 
-		if (!foundAtLeastOneNotNullCpeObj) {
-			fail();
-		}
-
-
-
-
-        if (nmapRun != null) {
-            System.out.println("hosts count: " + nmapRun.getHosts().size());
-        } else {
-            System.out.println("nmapRun is null");
-        }
     }
 
     @Test
@@ -176,22 +173,23 @@ public class OnePassParserTest implements IConstants {
 
         HostListener simpleListener = new HostListener();
 
-		InputStream is = getClass().getClassLoader().getResourceAsStream(NmapDataSamples.smbFileName);
+		try(InputStream is = getClass().getClassLoader().getResourceAsStream(NmapDataSamples.smbFileName)) {
 
-		String fileAsString = IOUtils.toString(is);
+			String fileAsString = IOUtils.toString( is );
 
-		opp.addListener(simpleListener);
-		nmapRun = opp.parse(fileAsString, OnePassParser.STRING_INPUT);
+			opp.addListener( simpleListener );
+			nmapRun = opp.parse( fileAsString, OnePassParser.STRING_INPUT );
 
-		ArrayList<Host> hosts = nmapRun.getHosts();
+			ArrayList<Host> hosts = nmapRun.getHosts();
 
-        if (nmapRun != null) {
-            if (nmapRun.getHosts().size() != simpleListener.getHostCount()) {
-                fail();
-            }
-        } else {
-            fail();
-        }
+			if (nmapRun != null) {
+				if (hosts.size() != simpleListener.getHostCount()) {
+					fail();
+				}
+			} else {
+				fail();
+			}
+		}
     }
 
     private class HostListener implements NMap4JParserEventListener {


### PR DESCRIPTION
Nueva versión de nmap4j para no perder la relación entre osmatch y osclass.

Tiene pinta de que no está implementado porque las versiones antiguas de nmap igual no lo tenían así.